### PR TITLE
Merge Updates Into Group18 (WebCanvas test script init)

### DIFF
--- a/group_specific_content/Group-18/WebUI/WebCanvas/WebCanvas.cpp
+++ b/group_specific_content/Group-18/WebUI/WebCanvas/WebCanvas.cpp
@@ -1,0 +1,79 @@
+#include "WebCanvas.hpp"
+
+#include <utility>
+#include <algorithm>  // std::stable_sort
+#include <vector>
+
+WebCanvas::WebCanvas(std::string id)
+  : m_id(std::move(id))
+{
+    if (m_id.empty()) {
+        m_id = "web-canvas";
+    }
+}
+
+// ---- IDomElement ----
+void WebCanvas::mountToLayout(WebLayout& parent, Alignment align)
+{
+    // Early stage: record the mount relationship only (no real DOM operations yet).
+    m_parent  = &parent;
+    m_align   = align;
+    m_mounted = true;
+}
+
+void WebCanvas::unmount()
+{
+    // Early stage: clear mount state only.
+    m_parent  = nullptr;
+    m_mounted = false;
+}
+
+void WebCanvas::syncFromModel()
+{
+    // Early stage: no-op (will later sync size/style/attributes to the real <canvas>).
+}
+
+const std::string& WebCanvas::Id() const
+{
+    return m_id;
+}
+
+// ---- Canvas management ----
+void WebCanvas::addElement(std::unique_ptr<ICanvasElement> element)
+{
+    if (element) {
+        m_elements.push_back(std::move(element));
+    }
+}
+
+void WebCanvas::clearElements()
+{
+    m_elements.clear();
+}
+
+void WebCanvas::renderFrame()
+{
+    // Build a non-owning view for scheduling without modifying ownership order.
+    std::vector<ICanvasElement*> ordered;
+    ordered.reserve(m_elements.size());
+
+    for (auto& up : m_elements) {
+        if (up) {
+            ordered.push_back(up.get());
+        }
+    }
+
+    // Stable sort by zIndex (ascending). Elements with the same zIndex keep insertion order.
+    std::stable_sort(ordered.begin(), ordered.end(),
+        [](const ICanvasElement* a, const ICanvasElement* b) {
+            return a->zIndex() < b->zIndex();
+        });
+
+    // Draw visible elements only.
+    for (auto* e : ordered) {
+        if (!e->visible()) {
+            continue;
+        }
+        e->draw(*this);
+    }
+}

--- a/group_specific_content/Group-18/WebUI/WebCanvas/WebCanvas.hpp
+++ b/group_specific_content/Group-18/WebUI/WebCanvas/WebCanvas.hpp
@@ -1,27 +1,44 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 
-#include "ICanvasElement.hpp"
+#include "../internal/IDomElement.hpp"
+#include "../internal/ICanvasElement.hpp"
 
 /**
  * WebCanvas
+ * - As an IDomElement: can be mounted/unmounted/synced by WebLayout (DOM lifecycle).
+ * - As a canvas manager: owns ICanvasElement objects and dispatches draw() in renderFrame().
  */
-class WebCanvas {
+class WebCanvas : public IDomElement {
 public:
-    WebCanvas() = default;
-    ~WebCanvas() = default;
+    explicit WebCanvas(std::string id = "web-canvas");
+    ~WebCanvas() override = default;
 
     WebCanvas(const WebCanvas&) = delete;
     WebCanvas& operator=(const WebCanvas&) = delete;
     WebCanvas(WebCanvas&&) = default;
     WebCanvas& operator=(WebCanvas&&) = default;
 
+    // ---- IDomElement ----
+    void mountToLayout(WebLayout& parent, Alignment align = Alignment::Start) override;
+    void unmount() override;
+    void syncFromModel() override;
+    const std::string& Id() const override;
+
+    // ---- Canvas content management ----
     void addElement(std::unique_ptr<ICanvasElement> element);
     void clearElements();
     void renderFrame();
 
 private:
     std::vector<std::unique_ptr<ICanvasElement>> m_elements;
+
+    // DOM-side state (minimal early-stage implementation)
+    std::string m_id;
+    WebLayout*  m_parent  = nullptr;       // Non-owning pointer to the parent layout
+    Alignment   m_align   = Alignment::Start;
+    bool        m_mounted = false;
 };

--- a/group_specific_content/Group-18/WebUI/WebCanvas/WebCanvasTest.cpp
+++ b/group_specific_content/Group-18/WebUI/WebCanvas/WebCanvasTest.cpp
@@ -1,0 +1,181 @@
+// File: tests/Interfaces/WebUI/WebCanvasTest.cpp
+// Notes:
+// - Do NOT define CATCH_CONFIG_MAIN here if another test file already defines it.
+
+#include <type_traits>
+#include <memory>
+#include <vector>
+
+//// For: tests/Interfaces/WebUI/WebCanvasTest.cpp
+// #include "../../../third-party/Catch/single_include/catch2/catch.hpp"
+// #include "../../../source/Interfaces/WebUI/WebCanvas.hpp"
+// #include "../../../source/Interfaces/WebUI/internal/ICanvasElement.hpp"
+//// For: group_specific_content/Group-18/WebUI/WebCanvas/WebCanvasTest.cpp
+#define CATCH_CONFIG_MAIN
+#include "../../../../third-party/Catch/single_include/catch2/catch.hpp"
+#include "./WebCanvas.hpp"
+#include "../internal/ICanvasElement.hpp"
+
+// A minimal WebLayout stub for unit tests.
+// This avoids pulling in the real WebLayout implementation (which may depend on emscripten).
+class WebLayout {};
+
+// ---------------------------
+// Test helpers
+// ---------------------------
+
+struct SpyElement : public ICanvasElement {
+    SpyElement(int id, std::vector<int>& order)
+        : id_(id), order_(order) {}
+
+    void draw(WebCanvas& /*canvas*/) override {
+        ++drawCount;
+        order_.push_back(id_);
+    }
+
+    // Directly mutate protected metadata for testing.
+    void setVisible(bool v) { m_metadata.visible = v; }
+    void setZIndex(int z) { m_metadata.zIndex = z; }
+
+    int drawCount = 0;
+
+private:
+    int id_;
+    std::vector<int>& order_;
+};
+
+struct LifetimeElement : public ICanvasElement {
+    static int alive;
+
+    LifetimeElement() { ++alive; }
+    ~LifetimeElement() override { --alive; }
+
+    void draw(WebCanvas& /*canvas*/) override {}
+};
+
+int LifetimeElement::alive = 0;
+
+// ---------------------------
+// Tests
+// ---------------------------
+
+TEST_CASE("WebCanvas is move-only (RAII-friendly)", "[web][canvas][raii]") {
+    STATIC_REQUIRE(!std::is_copy_constructible_v<WebCanvas>);
+    STATIC_REQUIRE(!std::is_copy_assignable_v<WebCanvas>);
+    STATIC_REQUIRE(std::is_move_constructible_v<WebCanvas>);
+    STATIC_REQUIRE(std::is_move_assignable_v<WebCanvas>);
+}
+
+TEST_CASE("WebCanvas implements IDomElement contract (compile-time)", "[web][canvas][dom]") {
+    STATIC_REQUIRE(std::is_base_of_v<IDomElement, WebCanvas>);
+}
+
+TEST_CASE("WebCanvas DOM lifecycle calls are safe and id is stable", "[web][canvas][dom]") {
+    WebCanvas canvas("canvas-test-1");
+    WebLayout layout;
+
+    REQUIRE(canvas.Id() == std::string("canvas-test-1"));
+
+    REQUIRE_NOTHROW(canvas.mountToLayout(layout, Alignment::Center));
+    REQUIRE_NOTHROW(canvas.syncFromModel());
+
+    // Unmount should be safe to call multiple times (idempotent behavior is recommended).
+    REQUIRE_NOTHROW(canvas.unmount());
+    REQUIRE_NOTHROW(canvas.unmount());
+
+    REQUIRE(canvas.Id() == std::string("canvas-test-1"));
+}
+
+TEST_CASE("WebCanvas owns added elements and releases them on clear/destroy", "[web][canvas][raii]") {
+    REQUIRE(LifetimeElement::alive == 0);
+
+    {
+        WebCanvas canvas;
+        canvas.addElement(std::make_unique<LifetimeElement>());
+        canvas.addElement(std::make_unique<LifetimeElement>());
+
+        REQUIRE(LifetimeElement::alive == 2);
+
+        canvas.clearElements();
+        REQUIRE(LifetimeElement::alive == 0);
+
+        canvas.addElement(std::make_unique<LifetimeElement>());
+        REQUIRE(LifetimeElement::alive == 1);
+    }
+
+    // After canvas destruction, all elements should be destroyed.
+    REQUIRE(LifetimeElement::alive == 0);
+}
+
+TEST_CASE("WebCanvas renderFrame draws elements (baseline behavior)", "[web][canvas]") {
+    WebCanvas canvas;
+
+    std::vector<int> order;
+    auto e1 = std::make_unique<SpyElement>(1, order);
+    auto e2 = std::make_unique<SpyElement>(2, order);
+
+    SpyElement* raw1 = e1.get();
+    SpyElement* raw2 = e2.get();
+
+    canvas.addElement(std::move(e1));
+    canvas.addElement(std::move(e2));
+
+    REQUIRE_NOTHROW(canvas.renderFrame());
+
+    CHECK(raw1->drawCount == 1);
+    CHECK(raw2->drawCount == 1);
+    CHECK(order == std::vector<int>({1, 2}));
+}
+
+TEST_CASE("WebCanvas ignores null elements safely", "[web][canvas]") {
+    WebCanvas canvas;
+    std::unique_ptr<ICanvasElement> nullElem;
+    REQUIRE_NOTHROW(canvas.addElement(std::move(nullElem)));
+    REQUIRE_NOTHROW(canvas.renderFrame());
+}
+
+TEST_CASE("WebCanvas renderFrame respects visibility (TDD target)", "[web][canvas][visibility]") {
+    WebCanvas canvas;
+
+    std::vector<int> order;
+    auto e1 = std::make_unique<SpyElement>(1, order);
+    auto e2 = std::make_unique<SpyElement>(2, order);
+
+    SpyElement* raw1 = e1.get();
+    SpyElement* raw2 = e2.get();
+
+    e2->setVisible(false);
+
+    canvas.addElement(std::move(e1));
+    canvas.addElement(std::move(e2));
+
+    canvas.renderFrame();
+
+    // Desired behavior: invisible elements should not draw.
+    CHECK(raw1->drawCount == 1);
+    CHECK(raw2->drawCount == 0);
+    CHECK(order == std::vector<int>({1}));
+}
+
+TEST_CASE("WebCanvas renderFrame sorts by zIndex (stable) (TDD target)", "[web][canvas][zindex]") {
+    WebCanvas canvas;
+
+    std::vector<int> order;
+    auto e1 = std::make_unique<SpyElement>(1, order);
+    auto e2 = std::make_unique<SpyElement>(2, order);
+    auto e3 = std::make_unique<SpyElement>(3, order);
+
+    // Assign zIndex values (lower draws first).
+    e1->setZIndex(10);
+    e2->setZIndex(0);
+    e3->setZIndex(10); // same as e1, should keep insertion order relative to e1
+
+    canvas.addElement(std::move(e1)); // id=1, z=10
+    canvas.addElement(std::move(e2)); // id=2, z=0
+    canvas.addElement(std::move(e3)); // id=3, z=10
+
+    canvas.renderFrame();
+
+    // Desired order: z=0 first, then z=10 elements in insertion order (1 then 3).
+    CHECK(order == std::vector<int>({2, 1, 3}));
+}

--- a/group_specific_content/Group-18/WebUI/internal/ICanvasElement.hpp
+++ b/group_specific_content/Group-18/WebUI/internal/ICanvasElement.hpp
@@ -10,6 +10,13 @@ public:
     virtual ~ICanvasElement() = default;
     virtual void draw(WebCanvas& canvas) = 0;
 
+    // Metadata accessors for the canvas scheduler (z-index ordering, visibility filtering).
+    int zIndex() const { return m_metadata.zIndex; }
+    bool visible() const { return m_metadata.visible; }
+
+    void setZIndex(int z) { m_metadata.zIndex = z; }
+    void setVisible(bool v) { m_metadata.visible = v; }
+
 protected:
     struct Metadata {
         int zIndex = 0;


### PR DESCRIPTION
Some changes include LLM-assisted code.

---

The ephemeral testing method in the current temporary path (run under repo root path)

```bash
em++ -std=c++23 -Wall -Wextra -Wpedantic -g -O0 -pthread -I third-party/Catch/single_include group_specific_content/Group-18/WebUI/WebCanvas/WebCanvas.cpp group_specific_content/Group-18/WebUI/WebCanvas/WebCanvasTest.cpp -o /tmp/run_tests && /tmp/run_tests
```

---

Run test based on `docker run` (run under repo root path)

(Bash)

```bash
docker run --rm -it -v "$PWD":/work -w /work emscripten/emsdk:latest bash -lc \
'em++ -std=c++23 -Wall -Wextra -Wpedantic -g -O0 -pthread \
  -I third-party/Catch/single_include \
  group_specific_content/Group-18/WebUI/WebCanvas/WebCanvas.cpp \
  group_specific_content/Group-18/WebUI/WebCanvas/WebCanvasTest.cpp \
  -o /tmp/run_tests && /tmp/run_tests'
```

(Powershell)

```powershell
docker run --rm -it -v ${PWD}:/work -w /work emscripten/emsdk:latest bash -lc `
'em++ -std=c++23 -Wall -Wextra -Wpedantic -g -O0 -pthread -I third-party/Catch/single_include group_specific_content/Group-18/WebUI/WebCanvas/WebCanvas.cpp group_specific_content/Group-18/WebUI/WebCanvas/WebCanvasTest.cpp -o /tmp/run_tests && /tmp/run_tests'
```

---

Result:

```powershell
===============================================================================
All tests passed (26 assertions in 8 test cases)
```