### PR TITLE
Add tools/Color.hpp and tests with getters/setters for multiple color formats

### DIFF
--- a/source/tools/Color.hpp
+++ b/source/tools/Color.hpp
@@ -1,0 +1,474 @@
+/**
+ * @file Color.hpp
+ * @brief Provides a unified color representation and conversion utilities.
+ *
+ * This file defines the Color class used across the project to represent
+ * RGBA colors. It supports construction from multiple formats such as
+ * RGBA integers, normalized floats, hexadecimal strings, and CSS-style
+ * rgb()/rgba() strings.
+ *
+ * The class is designed to be independent of external libraries.
+ * Adapters (e.g., SDL_Color conversion) should be implemented separately.
+ */
+
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace cse498 {
+
+class Color {
+public:
+    struct RGBA255 {
+        std::uint8_t r;
+        std::uint8_t g;
+        std::uint8_t b;
+        std::uint8_t a;
+    };
+
+    struct RGBA01 {
+        float r;
+        float g;
+        float b;
+        float a;
+    };
+
+    constexpr Color() = default;
+    constexpr Color(std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a = 255) noexcept
+        : r_(r), g_(g), b_(b), a_(a) {}
+
+    [[nodiscard]] static constexpr Color FromRGBA255(
+        std::uint8_t r,
+        std::uint8_t g,
+        std::uint8_t b,
+        std::uint8_t a = 255) noexcept {
+        return Color(r, g, b, a);
+    }
+
+    [[nodiscard]] static constexpr Color FromRGB255(
+        std::uint8_t r,
+        std::uint8_t g,
+        std::uint8_t b) noexcept {
+        return Color(r, g, b, 255);
+    }
+
+    [[nodiscard]] static Color FromRGBA01(float r, float g, float b, float a = 1.0f) noexcept {
+        return Color(
+            Float01ToByte(r),
+            Float01ToByte(g),
+            Float01ToByte(b),
+            Float01ToByte(a));
+    }
+
+    [[nodiscard]] static Color FromRGB01(float r, float g, float b) noexcept {
+        return FromRGBA01(r, g, b, 1.0f);
+    }
+
+    [[nodiscard]] static std::optional<Color> FromHex(std::string_view text) noexcept {
+        const std::string_view s = Trim(text);
+        if (s.empty()) {
+            return std::nullopt;
+        }
+
+        std::size_t pos = 0;
+        if (s[0] == '#') {
+            pos = 1;
+        }
+
+        const std::size_t len = s.size() - pos;
+        if (len == 3 || len == 4) {
+            const auto r = HexDigit(s[pos + 0]);
+            const auto g = HexDigit(s[pos + 1]);
+            const auto b = HexDigit(s[pos + 2]);
+            const auto a = (len == 4) ? HexDigit(s[pos + 3]) : 15;
+            if (!r || !g || !b || !a) {
+                return std::nullopt;
+            }
+            return Color(
+                ExpandNibble(*r),
+                ExpandNibble(*g),
+                ExpandNibble(*b),
+                ExpandNibble(*a));
+        }
+
+        if (len == 6 || len == 8) {
+            const auto r = HexByte(s[pos + 0], s[pos + 1]);
+            const auto g = HexByte(s[pos + 2], s[pos + 3]);
+            const auto b = HexByte(s[pos + 4], s[pos + 5]);
+            const auto a = (len == 8) ? HexByte(s[pos + 6], s[pos + 7]) : std::optional<std::uint8_t>(255);
+            if (!r || !g || !b || !a) {
+                return std::nullopt;
+            }
+            return Color(*r, *g, *b, *a);
+        }
+
+        return std::nullopt;
+    }
+
+    [[nodiscard]] static std::optional<Color> FromString(std::string_view text) noexcept {
+        const std::string_view s = Trim(text);
+        if (s.empty()) {
+            return std::nullopt;
+        }
+
+        if (StartsWithInsensitive(s, "#")) {
+            return FromHex(s);
+        }
+
+        if (StartsWithInsensitive(s, "rgb(")) {
+            return ParseRgbFunc(s, false);
+        }
+
+        if (StartsWithInsensitive(s, "rgba(")) {
+            return ParseRgbFunc(s, true);
+        }
+
+        if (EqualsInsensitive(s, "transparent")) {
+            return Color(0, 0, 0, 0);
+        }
+
+        if (const auto named = ParseNamedColor(s)) {
+            return named;
+        }
+
+        return std::nullopt;
+    }
+
+    [[nodiscard]] constexpr std::uint8_t R() const noexcept { return r_; }
+    [[nodiscard]] constexpr std::uint8_t G() const noexcept { return g_; }
+    [[nodiscard]] constexpr std::uint8_t B() const noexcept { return b_; }
+    [[nodiscard]] constexpr std::uint8_t A() const noexcept { return a_; }
+
+    constexpr void SetR(std::uint8_t value) noexcept { r_ = value; }
+    constexpr void SetG(std::uint8_t value) noexcept { g_ = value; }
+    constexpr void SetB(std::uint8_t value) noexcept { b_ = value; }
+    constexpr void SetA(std::uint8_t value) noexcept { a_ = value; }
+
+    void SetRGBA255(std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a = 255) noexcept {
+        r_ = r;
+        g_ = g;
+        b_ = b;
+        a_ = a;
+    }
+
+    void SetRGBA01(float r, float g, float b, float a = 1.0f) noexcept {
+        r_ = Float01ToByte(r);
+        g_ = Float01ToByte(g);
+        b_ = Float01ToByte(b);
+        a_ = Float01ToByte(a);
+    }
+
+    [[nodiscard]] constexpr RGBA255 ToRGBA255() const noexcept {
+        return RGBA255{r_, g_, b_, a_};
+    }
+
+    [[nodiscard]] RGBA01 ToRGBA01() const noexcept {
+        return RGBA01{
+            ByteToFloat01(r_),
+            ByteToFloat01(g_),
+            ByteToFloat01(b_),
+            ByteToFloat01(a_)};
+    }
+
+    [[nodiscard]] std::array<std::uint8_t, 4> ToArray() const noexcept {
+        return {r_, g_, b_, a_};
+    }
+
+    [[nodiscard]] std::string ToHex(bool include_alpha = false, bool uppercase = false) const {
+        std::string out;
+        out.reserve(include_alpha ? 9 : 7);
+        out.push_back('#');
+        AppendHexByte(out, r_, uppercase);
+        AppendHexByte(out, g_, uppercase);
+        AppendHexByte(out, b_, uppercase);
+        if (include_alpha) {
+            AppendHexByte(out, a_, uppercase);
+        }
+        return out;
+    }
+
+    [[nodiscard]] std::string ToRgbString() const {
+        return "rgb(" + std::to_string(static_cast<unsigned>(r_)) + ", " +
+               std::to_string(static_cast<unsigned>(g_)) + ", " +
+               std::to_string(static_cast<unsigned>(b_)) + ")";
+    }
+
+    [[nodiscard]] std::string ToRgbaString() const {
+        return "rgba(" + std::to_string(static_cast<unsigned>(r_)) + ", " +
+               std::to_string(static_cast<unsigned>(g_)) + ", " +
+               std::to_string(static_cast<unsigned>(b_)) + ", " +
+               AlphaString() + ")";
+    }
+
+    [[nodiscard]] constexpr bool operator==(const Color& other) const noexcept = default;
+
+private:
+    std::uint8_t r_ = 0;
+    std::uint8_t g_ = 0;
+    std::uint8_t b_ = 0;
+    std::uint8_t a_ = 255;
+
+    struct ParseCursor {
+        std::string_view s;
+        std::size_t pos = 0;
+    };
+
+    [[nodiscard]] static constexpr std::uint8_t ExpandNibble(std::uint8_t value) noexcept {
+        return static_cast<std::uint8_t>((value << 4U) | value);
+    }
+
+    [[nodiscard]] static std::uint8_t Float01ToByte(float value) noexcept {
+        const float clamped = Clamp01(value);
+        return static_cast<std::uint8_t>(std::lround(clamped * 255.0f));
+    }
+
+    [[nodiscard]] static float ByteToFloat01(std::uint8_t value) noexcept {
+        return static_cast<float>(value) / 255.0f;
+    }
+
+    [[nodiscard]] static constexpr float Clamp01(float value) noexcept {
+        return value < 0.0f ? 0.0f : (value > 1.0f ? 1.0f : value);
+    }
+
+    [[nodiscard]] static constexpr bool IsSpace(char c) noexcept {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+    }
+
+    [[nodiscard]] static std::string_view Trim(std::string_view s) noexcept {
+        while (!s.empty() && IsSpace(s.front())) {
+            s.remove_prefix(1);
+        }
+        while (!s.empty() && IsSpace(s.back())) {
+            s.remove_suffix(1);
+        }
+        return s;
+    }
+
+    [[nodiscard]] static constexpr char ToLowerAscii(char c) noexcept {
+        return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
+    }
+
+    [[nodiscard]] static bool EqualsInsensitive(std::string_view a, std::string_view b) noexcept {
+        if (a.size() != b.size()) {
+            return false;
+        }
+        for (std::size_t i = 0; i < a.size(); ++i) {
+            if (ToLowerAscii(a[i]) != ToLowerAscii(b[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    [[nodiscard]] static bool StartsWithInsensitive(std::string_view value, std::string_view prefix) noexcept {
+        if (value.size() < prefix.size()) {
+            return false;
+        }
+        return EqualsInsensitive(value.substr(0, prefix.size()), prefix);
+    }
+
+    [[nodiscard]] static std::optional<std::uint8_t> HexDigit(char c) noexcept {
+        if (c >= '0' && c <= '9') {
+            return static_cast<std::uint8_t>(c - '0');
+        }
+        if (c >= 'a' && c <= 'f') {
+            return static_cast<std::uint8_t>(10 + c - 'a');
+        }
+        if (c >= 'A' && c <= 'F') {
+            return static_cast<std::uint8_t>(10 + c - 'A');
+        }
+        return std::nullopt;
+    }
+
+    [[nodiscard]] static std::optional<std::uint8_t> HexByte(char hi, char lo) noexcept {
+        const auto h = HexDigit(hi);
+        const auto l = HexDigit(lo);
+        if (!h || !l) {
+            return std::nullopt;
+        }
+        return static_cast<std::uint8_t>((*h << 4U) | *l);
+    }
+
+    static void AppendHexByte(std::string& out, std::uint8_t value, bool uppercase) {
+        static constexpr char kLower[] = "0123456789abcdef";
+        static constexpr char kUpper[] = "0123456789ABCDEF";
+        const char* digits = uppercase ? kUpper : kLower;
+        out.push_back(digits[(value >> 4U) & 0x0F]);
+        out.push_back(digits[value & 0x0F]);
+    }
+
+    [[nodiscard]] std::string AlphaString() const {
+        const float a = ByteToFloat01(a_);
+        std::string s = std::to_string(a);
+        while (!s.empty() && s.back() == '0') {
+            s.pop_back();
+        }
+        if (!s.empty() && s.back() == '.') {
+            s.push_back('0');
+        }
+        return s;
+    }
+
+    [[nodiscard]] static std::optional<float> ParseFloatToken(std::string_view token) noexcept {
+        token = Trim(token);
+        if (token.empty()) {
+            return std::nullopt;
+        }
+
+        bool seen_dot = false;
+        bool seen_digit = false;
+        std::size_t i = 0;
+        if (token[i] == '+' || token[i] == '-') {
+            ++i;
+        }
+        for (; i < token.size(); ++i) {
+            const char c = token[i];
+            if (c >= '0' && c <= '9') {
+                seen_digit = true;
+                continue;
+            }
+            if (c == '.' && !seen_dot) {
+                seen_dot = true;
+                continue;
+            }
+            return std::nullopt;
+        }
+        if (!seen_digit) {
+            return std::nullopt;
+        }
+
+        try {
+            return std::stof(std::string(token));
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+
+    [[nodiscard]] static std::optional<std::uint8_t> ParseRgbChannel(std::string_view token) noexcept {
+        token = Trim(token);
+        if (token.empty()) {
+            return std::nullopt;
+        }
+
+        const bool is_percent = token.back() == '%';
+        if (is_percent) {
+            token.remove_suffix(1);
+            const auto value = ParseFloatToken(token);
+            if (!value) {
+                return std::nullopt;
+            }
+            return Float01ToByte(*value / 100.0f);
+        }
+
+        const auto value = ParseFloatToken(token);
+        if (!value) {
+            return std::nullopt;
+        }
+        const float v = *value < 0.0f ? 0.0f : (*value > 255.0f ? 255.0f : *value);
+        return static_cast<std::uint8_t>(std::lround(v));
+    }
+
+    [[nodiscard]] static std::optional<std::uint8_t> ParseAlphaChannel(std::string_view token) noexcept {
+        token = Trim(token);
+        if (token.empty()) {
+            return std::nullopt;
+        }
+
+        const bool is_percent = token.back() == '%';
+        if (is_percent) {
+            token.remove_suffix(1);
+            const auto value = ParseFloatToken(token);
+            if (!value) {
+                return std::nullopt;
+            }
+            return Float01ToByte(*value / 100.0f);
+        }
+
+        const auto value = ParseFloatToken(token);
+        if (!value) {
+            return std::nullopt;
+        }
+        return Float01ToByte(*value);
+    }
+
+    [[nodiscard]] static std::optional<Color> ParseRgbFunc(std::string_view text, bool expect_alpha) noexcept {
+        const auto left = text.find('(');
+        const auto right = text.rfind(')');
+        if (left == std::string_view::npos || right == std::string_view::npos || right <= left) {
+            return std::nullopt;
+        }
+
+        const std::string_view args = text.substr(left + 1, right - left - 1);
+        std::array<std::string_view, 4> parts{};
+        std::size_t count = 0;
+        std::size_t start = 0;
+
+        for (std::size_t i = 0; i <= args.size(); ++i) {
+            if (i == args.size() || args[i] == ',') {
+                if (count >= parts.size()) {
+                    return std::nullopt;
+                }
+                parts[count++] = args.substr(start, i - start);
+                start = i + 1;
+            }
+        }
+
+        if ((!expect_alpha && count != 3) || (expect_alpha && count != 4)) {
+            return std::nullopt;
+        }
+
+        const auto r = ParseRgbChannel(parts[0]);
+        const auto g = ParseRgbChannel(parts[1]);
+        const auto b = ParseRgbChannel(parts[2]);
+        const auto a = expect_alpha ? ParseAlphaChannel(parts[3]) : std::optional<std::uint8_t>(255);
+        if (!r || !g || !b || !a) {
+            return std::nullopt;
+        }
+
+        return Color(*r, *g, *b, *a);
+    }
+
+    [[nodiscard]] static std::optional<Color> ParseNamedColor(std::string_view text) noexcept {
+        struct NamedColor {
+            std::string_view name;
+            Color color;
+        };
+
+        static constexpr NamedColor kNamedColors[] = {
+            {"black", Color(0, 0, 0)},
+            {"white", Color(255, 255, 255)},
+            {"red", Color(255, 0, 0)},
+            {"green", Color(0, 128, 0)},
+            {"blue", Color(0, 0, 255)},
+            {"yellow", Color(255, 255, 0)},
+            {"cyan", Color(0, 255, 255)},
+            {"magenta", Color(255, 0, 255)},
+            {"gray", Color(128, 128, 128)},
+            {"grey", Color(128, 128, 128)},
+            {"orange", Color(255, 165, 0)},
+            {"purple", Color(128, 0, 128)},
+            {"pink", Color(255, 192, 203)},
+            {"brown", Color(165, 42, 42)},
+            {"lime", Color(0, 255, 0)},
+            {"navy", Color(0, 0, 128)},
+            {"teal", Color(0, 128, 128)},
+            {"silver", Color(192, 192, 192)},
+            {"maroon", Color(128, 0, 0)},
+            {"olive", Color(128, 128, 0)},
+        };
+
+        for (const auto& named : kNamedColors) {
+            if (EqualsInsensitive(text, named.name)) {
+                return named.color;
+            }
+        }
+        return std::nullopt;
+    }
+};
+
+} // namespace cse498

--- a/tests/tools/ColorTest.cpp
+++ b/tests/tools/ColorTest.cpp
@@ -1,0 +1,258 @@
+// File: tests/tools/ColorTest.cpp
+// Notes:
+// - Do NOT define CATCH_CONFIG_MAIN here if another test file already defines it.
+
+#include <array>
+#include <optional>
+#include <string>
+#include <type_traits>
+
+#include "../../third-party/Catch/single_include/catch2/catch.hpp"
+#include "../../source/tools/Color.hpp"
+
+using cse498::Color;
+
+TEST_CASE("Color is a lightweight value type", "[tools][color][traits]") {
+    STATIC_REQUIRE(std::is_default_constructible_v<Color>);
+    STATIC_REQUIRE(std::is_copy_constructible_v<Color>);
+    STATIC_REQUIRE(std::is_copy_assignable_v<Color>);
+    STATIC_REQUIRE(std::is_move_constructible_v<Color>);
+    STATIC_REQUIRE(std::is_move_assignable_v<Color>);
+}
+
+TEST_CASE("Color default construction yields opaque black", "[tools][color][ctor]") {
+    const Color color;
+
+    REQUIRE(color.R() == 0);
+    REQUIRE(color.G() == 0);
+    REQUIRE(color.B() == 0);
+    REQUIRE(color.A() == 255);
+}
+
+TEST_CASE("Color can be constructed from RGBA255 values", "[tools][color][rgba255]") {
+    const Color color = Color::FromRGBA255(12, 34, 56, 78);
+
+    REQUIRE(color.R() == 12);
+    REQUIRE(color.G() == 34);
+    REQUIRE(color.B() == 56);
+    REQUIRE(color.A() == 78);
+
+    const auto rgba = color.ToRGBA255();
+    REQUIRE(rgba.r == 12);
+    REQUIRE(rgba.g == 34);
+    REQUIRE(rgba.b == 56);
+    REQUIRE(rgba.a == 78);
+}
+
+TEST_CASE("Color can be constructed from RGB255 values with default alpha", "[tools][color][rgba255]") {
+    const Color color = Color::FromRGB255(12, 34, 56);
+
+    REQUIRE(color.R() == 12);
+    REQUIRE(color.G() == 34);
+    REQUIRE(color.B() == 56);
+    REQUIRE(color.A() == 255);
+}
+
+TEST_CASE("Color can be constructed from normalized float values", "[tools][color][rgba01]") {
+    const Color color = Color::FromRGBA01(1.0f, 0.5f, 0.0f, 0.25f);
+
+    REQUIRE(color.R() == 255);
+    REQUIRE(color.G() == 128);
+    REQUIRE(color.B() == 0);
+    REQUIRE(color.A() == 64);
+
+    const auto rgba01 = color.ToRGBA01();
+    REQUIRE(rgba01.r == Approx(1.0f));
+    REQUIRE(rgba01.g == Approx(128.0f / 255.0f));
+    REQUIRE(rgba01.b == Approx(0.0f));
+    REQUIRE(rgba01.a == Approx(64.0f / 255.0f));
+}
+
+TEST_CASE("Color clamps normalized float inputs to [0, 1]", "[tools][color][rgba01]") {
+    const Color color = Color::FromRGBA01(-1.0f, 2.0f, 0.25f, 5.0f);
+
+    REQUIRE(color.R() == 0);
+    REQUIRE(color.G() == 255);
+    REQUIRE(color.B() == 64);
+    REQUIRE(color.A() == 255);
+}
+
+TEST_CASE("Color setters update channels as expected", "[tools][color][setters]") {
+    Color color;
+
+    color.SetR(10);
+    color.SetG(20);
+    color.SetB(30);
+    color.SetA(40);
+
+    REQUIRE(color.R() == 10);
+    REQUIRE(color.G() == 20);
+    REQUIRE(color.B() == 30);
+    REQUIRE(color.A() == 40);
+
+    color.SetRGBA255(1, 2, 3, 4);
+    REQUIRE(color.R() == 1);
+    REQUIRE(color.G() == 2);
+    REQUIRE(color.B() == 3);
+    REQUIRE(color.A() == 4);
+
+    color.SetRGBA01(1.0f, 0.0f, 0.5f, 1.0f);
+    REQUIRE(color.R() == 255);
+    REQUIRE(color.G() == 0);
+    REQUIRE(color.B() == 128);
+    REQUIRE(color.A() == 255);
+}
+
+TEST_CASE("Color ToArray returns RGBA in order", "[tools][color][array]") {
+    const Color color = Color::FromRGBA255(9, 8, 7, 6);
+    const std::array<std::uint8_t, 4> values = color.ToArray();
+
+    REQUIRE(values == std::array<std::uint8_t, 4>{9, 8, 7, 6});
+}
+
+TEST_CASE("Color equality compares all channels", "[tools][color][equality]") {
+    const Color a = Color::FromRGBA255(1, 2, 3, 4);
+    const Color b = Color::FromRGBA255(1, 2, 3, 4);
+    const Color c = Color::FromRGBA255(1, 2, 3, 5);
+
+    REQUIRE(a == b);
+    REQUIRE_FALSE(a == c);
+}
+
+TEST_CASE("Color parses short and long hex forms", "[tools][color][hex]") {
+    SECTION("#RGB") {
+        const auto color = Color::FromHex("#f80");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 136);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 255);
+    }
+
+    SECTION("#RGBA") {
+        const auto color = Color::FromHex("#f804");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 136);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 68);
+    }
+
+    SECTION("#RRGGBB") {
+        const auto color = Color::FromHex("#ff8800");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 136);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 255);
+    }
+
+    SECTION("#RRGGBBAA") {
+        const auto color = Color::FromHex("#ff880040");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 136);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 64);
+    }
+
+    SECTION("hex without leading #") {
+        const auto color = Color::FromHex("336699");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 51);
+        REQUIRE(color->G() == 102);
+        REQUIRE(color->B() == 153);
+        REQUIRE(color->A() == 255);
+    }
+}
+
+TEST_CASE("Color rejects invalid hex strings", "[tools][color][hex]") {
+    REQUIRE_FALSE(Color::FromHex("" ).has_value());
+    REQUIRE_FALSE(Color::FromHex("#12").has_value());
+    REQUIRE_FALSE(Color::FromHex("#12345").has_value());
+    REQUIRE_FALSE(Color::FromHex("#zzzzzz").has_value());
+}
+
+TEST_CASE("Color formats hex strings", "[tools][color][hex]") {
+    const Color color = Color::FromRGBA255(255, 136, 0, 64);
+
+    REQUIRE(color.ToHex() == "#ff8800");
+    REQUIRE(color.ToHex(true) == "#ff880040");
+    REQUIRE(color.ToHex(false, true) == "#FF8800");
+    REQUIRE(color.ToHex(true, true) == "#FF880040");
+}
+
+TEST_CASE("Color parses rgb() strings", "[tools][color][string]") {
+    const auto color = Color::FromString("rgb(255, 128, 0)");
+
+    REQUIRE(color.has_value());
+    REQUIRE(color->R() == 255);
+    REQUIRE(color->G() == 128);
+    REQUIRE(color->B() == 0);
+    REQUIRE(color->A() == 255);
+}
+
+TEST_CASE("Color parses rgba() strings", "[tools][color][string]") {
+    SECTION("alpha as float") {
+        const auto color = Color::FromString("rgba(255, 128, 0, 0.5)");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 128);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 128);
+    }
+
+    SECTION("alpha as percent") {
+        const auto color = Color::FromString("rgba(255, 128, 0, 25%)");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 128);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 64);
+    }
+}
+
+TEST_CASE("Color parses percentage rgb() channels", "[tools][color][string]") {
+    const auto color = Color::FromString("rgb(100%, 50%, 0%)");
+
+    REQUIRE(color.has_value());
+    REQUIRE(color->R() == 255);
+    REQUIRE(color->G() == 128);
+    REQUIRE(color->B() == 0);
+    REQUIRE(color->A() == 255);
+}
+
+TEST_CASE("Color parses named colors and transparent", "[tools][color][string]") {
+    SECTION("named color") {
+        const auto color = Color::FromString("orange");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 165);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 255);
+    }
+
+    SECTION("transparent") {
+        const auto color = Color::FromString("transparent");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 0);
+        REQUIRE(color->G() == 0);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 0);
+    }
+}
+
+TEST_CASE("Color FromString rejects invalid strings", "[tools][color][string]") {
+    REQUIRE_FALSE(Color::FromString("").has_value());
+    REQUIRE_FALSE(Color::FromString("rgb(255, 0)").has_value());
+    REQUIRE_FALSE(Color::FromString("rgba(255, 0, 0)").has_value());
+    REQUIRE_FALSE(Color::FromString("rgb(255, nope, 0)").has_value());
+    REQUIRE_FALSE(Color::FromString("not-a-color").has_value());
+}
+
+TEST_CASE("Color string formatting matches stored values", "[tools][color][string]") {
+    const Color color = Color::FromRGBA255(255, 128, 0, 64);
+
+    REQUIRE(color.ToRgbString() == "rgb(255, 128, 0)");
+    REQUIRE(color.ToRgbaString() == "rgba(255, 128, 0, 0.25098)");
+}


### PR DESCRIPTION
This is a utility class developed to meet the needs of Group 18. Group 17 indicated that they might consider sharing this utility, so it was placed in the `tools` directory. 

Relevant Discord discussion:
https://discord.com/channels/1460361597015949513/1463682691454079052/1473063421049176239

---

Implement a Color object with getters and setters to support input, output, and conversion between different color formats.

Detailed usage can be found in the test files.

More than 95% of the code was generated by ChatGPT and manually reviewed.

References (in order of importance):
1. https://github.com/soreja/colorm
2. https://github.com/hugorplobo/colors.hpp
3. https://github.com/yuki-koyama/tinycolormap

---

Quick one-line test (in the project root):

```powershell
g++ -std=c++23 -Wall -Wextra -Wpedantic -DCATCH_CONFIG_MAIN tests/tools/ColorTest.cpp -o color_test && ./color_test
```

Expected result:

```powershell
/workspaces/Spring2026-CompanyA $ g++ -std=c++23 -Wall -Wextra -Wpedantic -DCATCH_CONFIG_MAIN tests/tools/ColorTest.cpp -o color_test && ./color_test
===============================================================================
All tests passed (118 assertions in 18 test cases)
```