### PR TITLE
Update tools/Color.hpp for constexpr and templates

### DIFF
--- a/source/tools/Color.hpp
+++ b/source/tools/Color.hpp
@@ -13,10 +13,13 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <cmath>
+#include <concepts>
 #include <cstdint>
 #include <optional>
+#include <ranges>
 #include <string>
 #include <string_view>
 
@@ -39,7 +42,12 @@ public:
     };
 
     constexpr Color() = default;
-    constexpr Color(std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a = 255) noexcept
+
+    constexpr Color(
+        std::uint8_t r,
+        std::uint8_t g,
+        std::uint8_t b,
+        std::uint8_t a = 255) noexcept
         : r_(r), g_(g), b_(b), a_(a) {}
 
     [[nodiscard]] static constexpr Color FromRGBA255(
@@ -57,6 +65,32 @@ public:
         return Color(r, g, b, 255);
     }
 
+    template <std::integral T>
+    [[nodiscard]] static constexpr Color FromRGBIntegral(
+        T r,
+        T g,
+        T b,
+        T a = static_cast<T>(255)) noexcept {
+        return Color(
+            ClampToByte(r),
+            ClampToByte(g),
+            ClampToByte(b),
+            ClampToByte(a));
+    }
+
+    template <std::floating_point T>
+    [[nodiscard]] static Color FromRGBNormalized(
+        T r,
+        T g,
+        T b,
+        T a = static_cast<T>(1)) noexcept {
+        return FromRGBA01(
+            static_cast<float>(r),
+            static_cast<float>(g),
+            static_cast<float>(b),
+            static_cast<float>(a));
+    }
+
     [[nodiscard]] static Color FromRGBA01(float r, float g, float b, float a = 1.0f) noexcept {
         return Color(
             Float01ToByte(r),
@@ -69,7 +103,7 @@ public:
         return FromRGBA01(r, g, b, 1.0f);
     }
 
-    [[nodiscard]] static std::optional<Color> FromHex(std::string_view text) noexcept {
+    [[nodiscard]] static constexpr std::optional<Color> FromHex(std::string_view text) noexcept {
         const std::string_view s = Trim(text);
         if (s.empty()) {
             return std::nullopt;
@@ -85,10 +119,12 @@ public:
             const auto r = HexDigit(s[pos + 0]);
             const auto g = HexDigit(s[pos + 1]);
             const auto b = HexDigit(s[pos + 2]);
-            const auto a = (len == 4) ? HexDigit(s[pos + 3]) : 15;
+            const auto a = (len == 4) ? HexDigit(s[pos + 3]) : std::optional<std::uint8_t>(15);
+
             if (!r || !g || !b || !a) {
                 return std::nullopt;
             }
+
             return Color(
                 ExpandNibble(*r),
                 ExpandNibble(*g),
@@ -100,10 +136,14 @@ public:
             const auto r = HexByte(s[pos + 0], s[pos + 1]);
             const auto g = HexByte(s[pos + 2], s[pos + 3]);
             const auto b = HexByte(s[pos + 4], s[pos + 5]);
-            const auto a = (len == 8) ? HexByte(s[pos + 6], s[pos + 7]) : std::optional<std::uint8_t>(255);
+            const auto a = (len == 8)
+                               ? HexByte(s[pos + 6], s[pos + 7])
+                               : std::optional<std::uint8_t>(255);
+
             if (!r || !g || !b || !a) {
                 return std::nullopt;
             }
+
             return Color(*r, *g, *b, *a);
         }
 
@@ -149,7 +189,11 @@ public:
     constexpr void SetB(std::uint8_t value) noexcept { b_ = value; }
     constexpr void SetA(std::uint8_t value) noexcept { a_ = value; }
 
-    void SetRGBA255(std::uint8_t r, std::uint8_t g, std::uint8_t b, std::uint8_t a = 255) noexcept {
+    constexpr void SetRGBA255(
+        std::uint8_t r,
+        std::uint8_t g,
+        std::uint8_t b,
+        std::uint8_t a = 255) noexcept {
         r_ = r;
         g_ = g;
         b_ = b;
@@ -167,16 +211,16 @@ public:
         return RGBA255{r_, g_, b_, a_};
     }
 
+    [[nodiscard]] constexpr std::array<std::uint8_t, 4> ToArray() const noexcept {
+        return {r_, g_, b_, a_};
+    }
+
     [[nodiscard]] RGBA01 ToRGBA01() const noexcept {
         return RGBA01{
             ByteToFloat01(r_),
             ByteToFloat01(g_),
             ByteToFloat01(b_),
             ByteToFloat01(a_)};
-    }
-
-    [[nodiscard]] std::array<std::uint8_t, 4> ToArray() const noexcept {
-        return {r_, g_, b_, a_};
     }
 
     [[nodiscard]] std::string ToHex(bool include_alpha = false, bool uppercase = false) const {
@@ -208,18 +252,55 @@ public:
     [[nodiscard]] constexpr bool operator==(const Color& other) const noexcept = default;
 
 private:
+    struct NamedColorEntry {
+        std::string_view name;
+        std::uint8_t r;
+        std::uint8_t g;
+        std::uint8_t b;
+        std::uint8_t a;
+    };
+
     std::uint8_t r_ = 0;
     std::uint8_t g_ = 0;
     std::uint8_t b_ = 0;
     std::uint8_t a_ = 255;
 
-    struct ParseCursor {
-        std::string_view s;
-        std::size_t pos = 0;
-    };
+    static constexpr std::array<NamedColorEntry, 20> kNamedColors{{
+        {"black",   0,   0,   0,   255},
+        {"white",   255, 255, 255, 255},
+        {"red",     255, 0,   0,   255},
+        {"green",   0,   128, 0,   255},
+        {"blue",    0,   0,   255, 255},
+        {"yellow",  255, 255, 0,   255},
+        {"cyan",    0,   255, 255, 255},
+        {"magenta", 255, 0,   255, 255},
+        {"gray",    128, 128, 128, 255},
+        {"grey",    128, 128, 128, 255},
+        {"orange",  255, 165, 0,   255},
+        {"purple",  128, 0,   128, 255},
+        {"pink",    255, 192, 203, 255},
+        {"brown",   165, 42,  42,  255},
+        {"lime",    0,   255, 0,   255},
+        {"navy",    0,   0,   128, 255},
+        {"teal",    0,   128, 128, 255},
+        {"silver",  192, 192, 192, 255},
+        {"maroon",  128, 0,   0,   255},
+        {"olive",   128, 128, 0,   255},
+    }};
 
     [[nodiscard]] static constexpr std::uint8_t ExpandNibble(std::uint8_t value) noexcept {
         return static_cast<std::uint8_t>((value << 4U) | value);
+    }
+
+    template <std::integral T>
+    [[nodiscard]] static constexpr std::uint8_t ClampToByte(T value) noexcept {
+        if (value < static_cast<T>(0)) {
+            return 0;
+        }
+        if (value > static_cast<T>(255)) {
+            return 255;
+        }
+        return static_cast<std::uint8_t>(value);
     }
 
     [[nodiscard]] static std::uint8_t Float01ToByte(float value) noexcept {
@@ -236,10 +317,11 @@ private:
     }
 
     [[nodiscard]] static constexpr bool IsSpace(char c) noexcept {
-        return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
+               c == '\f' || c == '\v';
     }
 
-    [[nodiscard]] static std::string_view Trim(std::string_view s) noexcept {
+    [[nodiscard]] static constexpr std::string_view Trim(std::string_view s) noexcept {
         while (!s.empty() && IsSpace(s.front())) {
             s.remove_prefix(1);
         }
@@ -250,13 +332,18 @@ private:
     }
 
     [[nodiscard]] static constexpr char ToLowerAscii(char c) noexcept {
-        return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
+        return (c >= 'A' && c <= 'Z')
+                   ? static_cast<char>(c - 'A' + 'a')
+                   : c;
     }
 
-    [[nodiscard]] static bool EqualsInsensitive(std::string_view a, std::string_view b) noexcept {
+    [[nodiscard]] static constexpr bool EqualsInsensitive(
+        std::string_view a,
+        std::string_view b) noexcept {
         if (a.size() != b.size()) {
             return false;
         }
+
         for (std::size_t i = 0; i < a.size(); ++i) {
             if (ToLowerAscii(a[i]) != ToLowerAscii(b[i])) {
                 return false;
@@ -265,14 +352,16 @@ private:
         return true;
     }
 
-    [[nodiscard]] static bool StartsWithInsensitive(std::string_view value, std::string_view prefix) noexcept {
+    [[nodiscard]] static constexpr bool StartsWithInsensitive(
+        std::string_view value,
+        std::string_view prefix) noexcept {
         if (value.size() < prefix.size()) {
             return false;
         }
         return EqualsInsensitive(value.substr(0, prefix.size()), prefix);
     }
 
-    [[nodiscard]] static std::optional<std::uint8_t> HexDigit(char c) noexcept {
+    [[nodiscard]] static constexpr std::optional<std::uint8_t> HexDigit(char c) noexcept {
         if (c >= '0' && c <= '9') {
             return static_cast<std::uint8_t>(c - '0');
         }
@@ -285,7 +374,7 @@ private:
         return std::nullopt;
     }
 
-    [[nodiscard]] static std::optional<std::uint8_t> HexByte(char hi, char lo) noexcept {
+    [[nodiscard]] static constexpr std::optional<std::uint8_t> HexByte(char hi, char lo) noexcept {
         const auto h = HexDigit(hi);
         const auto l = HexDigit(lo);
         if (!h || !l) {
@@ -298,6 +387,7 @@ private:
         static constexpr char kLower[] = "0123456789abcdef";
         static constexpr char kUpper[] = "0123456789ABCDEF";
         const char* digits = uppercase ? kUpper : kLower;
+
         out.push_back(digits[(value >> 4U) & 0x0F]);
         out.push_back(digits[value & 0x0F]);
     }
@@ -305,12 +395,14 @@ private:
     [[nodiscard]] std::string AlphaString() const {
         const float a = ByteToFloat01(a_);
         std::string s = std::to_string(a);
+
         while (!s.empty() && s.back() == '0') {
             s.pop_back();
         }
         if (!s.empty() && s.back() == '.') {
             s.push_back('0');
         }
+
         return s;
     }
 
@@ -323,12 +415,18 @@ private:
         bool seen_dot = false;
         bool seen_digit = false;
         std::size_t i = 0;
+
         if (token[i] == '+' || token[i] == '-') {
             ++i;
         }
+
+        const auto is_digit = [](char c) noexcept {
+            return c >= '0' && c <= '9';
+        };
+
         for (; i < token.size(); ++i) {
             const char c = token[i];
-            if (c >= '0' && c <= '9') {
+            if (is_digit(c)) {
                 seen_digit = true;
                 continue;
             }
@@ -338,6 +436,7 @@ private:
             }
             return std::nullopt;
         }
+
         if (!seen_digit) {
             return std::nullopt;
         }
@@ -369,6 +468,7 @@ private:
         if (!value) {
             return std::nullopt;
         }
+
         const float v = *value < 0.0f ? 0.0f : (*value > 255.0f ? 255.0f : *value);
         return static_cast<std::uint8_t>(std::lround(v));
     }
@@ -393,13 +493,18 @@ private:
         if (!value) {
             return std::nullopt;
         }
+
         return Float01ToByte(*value);
     }
 
-    [[nodiscard]] static std::optional<Color> ParseRgbFunc(std::string_view text, bool expect_alpha) noexcept {
+    [[nodiscard]] static std::optional<Color> ParseRgbFunc(
+        std::string_view text,
+        bool expect_alpha) noexcept {
         const auto left = text.find('(');
         const auto right = text.rfind(')');
-        if (left == std::string_view::npos || right == std::string_view::npos || right <= left) {
+        if (left == std::string_view::npos ||
+            right == std::string_view::npos ||
+            right <= left) {
             return std::nullopt;
         }
 
@@ -425,7 +530,10 @@ private:
         const auto r = ParseRgbChannel(parts[0]);
         const auto g = ParseRgbChannel(parts[1]);
         const auto b = ParseRgbChannel(parts[2]);
-        const auto a = expect_alpha ? ParseAlphaChannel(parts[3]) : std::optional<std::uint8_t>(255);
+        const auto a = expect_alpha
+                           ? ParseAlphaChannel(parts[3])
+                           : std::optional<std::uint8_t>(255);
+
         if (!r || !g || !b || !a) {
             return std::nullopt;
         }
@@ -434,40 +542,17 @@ private:
     }
 
     [[nodiscard]] static std::optional<Color> ParseNamedColor(std::string_view text) noexcept {
-        struct NamedColor {
-            std::string_view name;
-            Color color;
-        };
+        const auto it = std::ranges::find_if(
+            kNamedColors,
+            [&](const NamedColorEntry& named) noexcept {
+                return EqualsInsensitive(text, named.name);
+            });
 
-        static constexpr NamedColor kNamedColors[] = {
-            {"black", Color(0, 0, 0)},
-            {"white", Color(255, 255, 255)},
-            {"red", Color(255, 0, 0)},
-            {"green", Color(0, 128, 0)},
-            {"blue", Color(0, 0, 255)},
-            {"yellow", Color(255, 255, 0)},
-            {"cyan", Color(0, 255, 255)},
-            {"magenta", Color(255, 0, 255)},
-            {"gray", Color(128, 128, 128)},
-            {"grey", Color(128, 128, 128)},
-            {"orange", Color(255, 165, 0)},
-            {"purple", Color(128, 0, 128)},
-            {"pink", Color(255, 192, 203)},
-            {"brown", Color(165, 42, 42)},
-            {"lime", Color(0, 255, 0)},
-            {"navy", Color(0, 0, 128)},
-            {"teal", Color(0, 128, 128)},
-            {"silver", Color(192, 192, 192)},
-            {"maroon", Color(128, 0, 0)},
-            {"olive", Color(128, 128, 0)},
-        };
-
-        for (const auto& named : kNamedColors) {
-            if (EqualsInsensitive(text, named.name)) {
-                return named.color;
-            }
+        if (it == kNamedColors.end()) {
+            return std::nullopt;
         }
-        return std::nullopt;
+
+        return Color(it->r, it->g, it->b, it->a);
     }
 };
 

--- a/tests/tools/ColorTest.cpp
+++ b/tests/tools/ColorTest.cpp
@@ -1,6 +1,10 @@
-// File: tests/tools/ColorTest.cpp
-// Notes:
-// - Do NOT define CATCH_CONFIG_MAIN here if another test file already defines it.
+/**
+ * @file ColorTest.cpp
+ * @brief Contains Catch2 test cases for the Color class.
+ *
+ * @note Do not define CATCH_CONFIG_MAIN in this file if it is already
+ * defined in another test translation unit.
+ */
 
 #include <array>
 #include <optional>
@@ -255,4 +259,66 @@ TEST_CASE("Color string formatting matches stored values", "[tools][color][strin
 
     REQUIRE(color.ToRgbString() == "rgb(255, 128, 0)");
     REQUIRE(color.ToRgbaString() == "rgba(255, 128, 0, 0.25098)");
+}
+
+TEST_CASE("Color supports constexpr construction and access", "[tools][color][constexpr]") {
+    constexpr Color color = Color::FromRGBA255(1, 2, 3, 4);
+
+    STATIC_REQUIRE(color.R() == 1);
+    STATIC_REQUIRE(color.G() == 2);
+    STATIC_REQUIRE(color.B() == 3);
+    STATIC_REQUIRE(color.A() == 4);
+
+    constexpr auto values = color.ToArray();
+    STATIC_REQUIRE(values[0] == 1);
+    STATIC_REQUIRE(values[1] == 2);
+    STATIC_REQUIRE(values[2] == 3);
+    STATIC_REQUIRE(values[3] == 4);
+}
+
+TEST_CASE("Color template integral factory clamps into byte range", "[tools][color][templates]") {
+    const Color color = Color::FromRGBIntegral(-10, 300, 42, 999);
+
+    REQUIRE(color.R() == 0);
+    REQUIRE(color.G() == 255);
+    REQUIRE(color.B() == 42);
+    REQUIRE(color.A() == 255);
+}
+
+TEST_CASE("Color template floating-point factory accepts multiple float types", "[tools][color][templates]") {
+    const Color color = Color::FromRGBNormalized(1.0, 0.5, 0.0, 0.25);
+
+    REQUIRE(color.R() == 255);
+    REQUIRE(color.G() == 128);
+    REQUIRE(color.B() == 0);
+    REQUIRE(color.A() == 64);
+}
+
+TEST_CASE("Color parsing is case-insensitive for named colors and prefixes", "[tools][color][string]") {
+    SECTION("named color") {
+        const auto color = Color::FromString("OrAnGe");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 165);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 255);
+    }
+
+    SECTION("RGB prefix") {
+        const auto color = Color::FromString("RGB(255, 128, 0)");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 128);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 255);
+    }
+
+    SECTION("RGBA prefix") {
+        const auto color = Color::FromString("RgBa(255, 128, 0, 0.5)");
+        REQUIRE(color.has_value());
+        REQUIRE(color->R() == 255);
+        REQUIRE(color->G() == 128);
+        REQUIRE(color->B() == 0);
+        REQUIRE(color->A() == 128);
+    }
 }


### PR DESCRIPTION
Update Color class methods to use constexpr where applicable and improve readability. Added template functions for handling integral and floating-point types in color conversion.

Added test cases for Color class functionality, including constexpr construction, factory methods, and case-insensitive parsing.

This commit was made with help by LLM tools.