### PR TITLE
Fixed Timer Tests to not fail on certain builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -148,13 +148,13 @@ Group 18's demo requires the Emscripten toolchain. See the [Web Tests setup](#se
 Open automatically in Chrome:
 
 ```bash
-emrun demos/WebUI/index.html --browser chrome --serve-root .
+emrun demos/WebUI/index.html --browser chrome --serve_root .
 ```
 
 Or start the server without opening a browser:
 
 ```bash
-emrun demos/WebUI/index.html --no_browser --serve-root .
+emrun demos/WebUI/index.html --no_browser --serve_root .
 ```
 
 Then navigate to:

--- a/source/Agents/Classic/MovementTypes.hpp
+++ b/source/Agents/Classic/MovementTypes.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cmath>
 #include <string>
 
 namespace cse498

--- a/tests/tools/TimerTest.cpp
+++ b/tests/tools/TimerTest.cpp
@@ -6,18 +6,21 @@ TEST_CASE("Timer Constructor", "[Timer]") {
   // Test that single parameter constructor defaults the Timer to running.
   cse498::Timer Timer("Test1");
   REQUIRE(Timer.isRunning());
+  Timer.advanceTime(1.0);
   REQUIRE(Timer.elapsed() > 0);
 
   // Test that adding true in the constructor functions properly and starts the
   // Timer running.
   cse498::Timer Timer2("Test2", true);
   REQUIRE(Timer2.isRunning());
+  Timer2.advanceTime(1.0);
   REQUIRE(Timer2.elapsed() > 0);
 
   // Test that adding false in the constructor starts the Timer paused
   // and that the elapsed time defualts to 0.
   cse498::Timer Timer3("Test3", false);
   REQUIRE(!Timer3.isRunning());
+  Timer3.advanceTime(1.0);
   REQUIRE(Timer3.elapsed() == 0.0);
 }
 
@@ -26,12 +29,14 @@ TEST_CASE("Timer Start Method", "[Timer]") {
   // intended.
   cse498::Timer Timer("Test1", false);
   REQUIRE(!Timer.isRunning());
+  Timer.advanceTime(1.0);
   REQUIRE(Timer.elapsed() == 0.0);
 
   // Call start on the Timer and make sure that it is running and that time is
   // elapsing.
   Timer.start();
   REQUIRE(Timer.isRunning());
+  Timer.advanceTime(1.0);
   REQUIRE(Timer.elapsed() > 0);
 
   // Make sure that calling start on a running Timer doesn't change the state.
@@ -50,6 +55,7 @@ TEST_CASE("Timer Stop Method", "[Timer]") {
   // elapsing.
   Timer.start();
   REQUIRE(Timer.isRunning());
+  Timer.advanceTime(1.0);
   REQUIRE(Timer.elapsed() > 0);
 
   // Call stop on the Timer and make sure that it is no longer running.


### PR DESCRIPTION
Test cases which included 'REQUIRE(Timer.elapsed() > 0)' were failing on some builds due to taking really close to 0 seconds. This updates the tests so that they use the advanceTime() function in order to be significantly over 0 only in the case that the timer is running.