### PR TITLE
WebButton: updated docs, expanded tests, minor bug fix

### DIFF
--- a/docs/ClassSpecs/Interfaces/WebUI/WebButton.md
+++ b/docs/ClassSpecs/Interfaces/WebUI/WebButton.md
@@ -5,7 +5,7 @@
 
 # Group 18's Write-up for Initial C++ Class (WebUI)
 
-*Last updated: Feb 16, 2026*
+*Last updated: Apr 20, 2026*
 
 ## 3.3 `WebButton` Class Specification
 
@@ -17,7 +17,9 @@ A C++ class that represents a clickable button in the Web UI. It manages an HTML
 
 `WebButton` is a reusable UI component: it stores *what* the button looks like and *how* it behaves, but **not** *where* it is rendered. Positioning is handled by `WebLayout` (Flex/Grid/Free).
 
-The class implements the **`IDomElement`** interface for integration with `WebLayout` (DOM-based rendering).
+The class implements the **`IDomElement`** interface for integration with `WebLayout` (DOM-based rendering) and the **`ICanvasElement`** interface for optional drawing onto a `WebCanvas`.
+
+All classes live under the `cse498` namespace.
 
 ---
 
@@ -26,12 +28,13 @@ The class implements the **`IDomElement`** interface for integration with `WebLa
 - **`std::function`** - for storing the click callback
 - **`std::string`** - for storing label text
 - **Emscripten's `val`** - for JavaScript/DOM interaction
+- **`std::invocable` (C++20 concept)** - used to constrain the template `SetCallback` overload
 
 ---
 
 ### 3.3.3 Key Functions
 
-#### Construction & Destruction
+#### Construction and Destruction
 
 ```cpp
 explicit WebButton(const std::string& label = "");
@@ -55,8 +58,15 @@ std::string GetLabel() const;
 
 ```cpp
 void SetCallback(std::function<void()> callback);
+
+template<typename F>
+    requires std::invocable<F>
+void SetCallback(F&& callable);
+
 void Click();
 ```
+
+The template overload accepts any callable type (lambda, functor, function pointer) without requiring an explicit `std::function` wrap.
 
 #### Size
 
@@ -65,6 +75,8 @@ void SetSize(int width, int height);
 int GetWidth() const;
 int GetHeight() const;
 ```
+
+Passing 0 for width or height means use the browser default.
 
 #### Styling
 
@@ -87,11 +99,30 @@ bool IsVisible() const;
 #### IDomElement Interface
 
 ```cpp
-void mountToLayout(WebLayout& parent, Alignment align = Alignment::Start) override;
-void unmount() override;
-void syncFromModel() override;
-const std::string& Id() const override;
+void MountToLayout(WebLayout& parent, Alignment align = Alignment::Start) override;
+void SyncFromModel() override;
 ```
+
+`MountToLayout` delegates to `WebLayout::AddElement`. `SyncFromModel` pushes the current model state (label, size, colors, enabled, visible) to the DOM element.
+
+The `Unmount()` and `Id()` methods are inherited from the `IDomElement` base class.
+
+#### ICanvasElement Interface
+
+```cpp
+void SetCanvasRect(float x, float y, float w = -1.0f, float h = -1.0f);
+void Draw(WebCanvas& canvas) override;
+```
+
+`SetCanvasRect` sets the position and size for canvas rendering. `Draw` renders the button background rectangle and centered label text onto a `WebCanvas`.
+
+#### Internal
+
+```cpp
+void HandleClick();
+```
+
+Called by the JavaScript click listener trampoline to forward DOM click events into C++.
 
 ---
 
@@ -102,7 +133,7 @@ const std::string& Id() const override;
 | Programmer error | Negative width/height, null callback | `assert()` |
 | User error | Clicking disabled button | Ignore silently |
 
-Following instructor guidance, **no C++ exceptions** will be thrown inside `WebButton` for WebAssembly builds.
+Following instructor guidance, **no C++ exceptions** are thrown inside `WebButton` for WebAssembly builds.
 
 ---
 
@@ -112,6 +143,7 @@ Following instructor guidance, **no C++ exceptions** will be thrown inside `WebB
 - DOM manipulation from C++
 - Memory cleanup (removing DOM elements, unbinding listeners)
 - Coordinating with WebLayout for proper mount/unmount lifecycle
+- Canvas rendering as an alternative to DOM-based display
 
 ---
 
@@ -122,40 +154,53 @@ Following instructor guidance, **no C++ exceptions** will be thrown inside `WebB
 | `WebLayout` | 18 | Manages button positioning via IDomElement interface |
 | `WebTextbox` | 18 | Shared IDomElement pattern, consistent styling approach |
 | `WebImage` | 18 | Shared IDomElement pattern, consistent lifecycle |
-| `WebCanvas` | 18 | Optional: visual representation of buttons inside canvas |
+| `WebCanvas` | 18 | ICanvasElement rendering for canvas-based display |
+| `WebInterface` | 18 | Main menu buttons, pause menu, settings menu |
+| `Color` | 18 | Compile-time color validation for default hex values |
 | `ActionMap` | 2 (Classic Agents) | Similar string-to-function mapping pattern |
 | `Menu` | 17 (GUI Interface) | Common interface for both GUI systems |
-| `OutputManager` | 16 (Data Analytics) | Logging button events |
 
 ---
 
 ### 3.3.7 File Structure
 
 ```
-WebUI/WebButton/
-  WebButton.hpp        # Header with class declaration
-  WebButton.cpp        # Implementation using Emscripten
-  WebButtonTest.cpp    # Unit tests (Catch2)
-  main.cpp             # Demo program
-  index.html           # Demo HTML page
+source/Interfaces/WebUI/WebButton/
+    WebButton.hpp          # Header with class declaration
+    WebButton.cpp          # Implementation using Emscripten
+    main.cpp               # Standalone demo program
+
+tests/Interfaces/WebUI/
+    WebButtonTest.cpp      # Unit tests (Catch2, 47 test cases)
+
+demos/WebUI/
+    Group18_main.cpp       # Full integrated demo
+    index.html             # Demo HTML page
 ```
 
 ---
 
-### 3.3.8 Unit Test Run Instructions (`WebButtonTest.cpp`)
+### 3.3.8 Build and Test Instructions
 
-The test file uses Catch2 and can be compiled natively (without Emscripten) since it stubs out DOM dependencies. From the repo root:
-
-```bash
-make test
-```
-
-Or compile directly:
+#### Building the demo (from repo root)
 
 ```bash
-g++ -std=c++20 -I third-party/Catch/single_include \
-  WebButtonTest.cpp -o webbutton_test && ./webbutton_test
+cmake -S . -B build
+cmake --build build --target group18_demo
+emrun demos/WebUI/index.html --no_browser --serve_root .
 ```
+
+Then open `http://localhost:6931/demos/WebUI/index.html` in a browser.
+
+#### Building and running tests (from repo root)
+
+```bash
+cmake --build build --target web_test
+cd tests/build/web_tests
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000/WebButtonTest.html` in a browser. Test results appear in the browser console (F12).
 
 ---
 
@@ -164,4 +209,5 @@ g++ -std=c++20 -I third-party/Catch/single_include \
 | Date | Changes |
 |------|---------|
 | Jan 30, 2026 | Initial specification |
-| Feb 16, 2026 | **v2**: Removed position control (handled by WebLayout); implemented IDomElement interface (mountToLayout, unmount, syncFromModel, Id); added unique ID generation; added GetWidth/GetHeight; updated tests to Catch2; aligned patterns with WebImage and WebTextbox |
+| Feb 16, 2026 | Removed position control (handled by WebLayout); implemented IDomElement interface; added unique ID generation; added GetWidth/GetHeight; updated tests to Catch2 |
+| Apr 20, 2026 | Added ICanvasElement interface (SetCanvasRect, Draw); added template SetCallback overload with std::invocable constraint; added cse498 namespace; updated IDomElement methods to PascalCase (MountToLayout, SyncFromModel); added compile-time color validation via Color utility; expanded test suite to 47 test cases; updated file structure and build instructions to CMake; added coordination with WebInterface and Color |

--- a/source/Interfaces/WebUI/internal/IDomElement.hpp
+++ b/source/Interfaces/WebUI/internal/IDomElement.hpp
@@ -78,7 +78,7 @@ public:
     ///        Can be overridden to allow side effects.
     /// @param element a pointer to the child element to remove
     virtual void RemoveChild(IDomElement* element) {
-        if (mElement.isNull() && mElement.isUndefined()) {
+        if (mElement.isNull() || mElement.isUndefined()) {
             GetConsole().call<void>("warn", "element with Id: " + Id() + " is undefined");
             return;
         };

--- a/tests/Interfaces/WebUI/WebButtonTest.cpp
+++ b/tests/Interfaces/WebUI/WebButtonTest.cpp
@@ -676,4 +676,206 @@ TEST_CASE("Large size values are stored correctly", "[WebButton]") {
     CHECK_MSG(btn.GetHeight() == 3000, "large height should be stored");
 }
 
+// ========================================================
+// Test 48: Template SetCallback with lambda
+// ========================================================
+TEST_CASE("Template SetCallback with lambda", "[WebButton]") {
+    WebButton btn("test");
+    int count = 0;
+
+    auto lambda = [&count]() { ++count; };
+    btn.SetCallback(std::move(lambda));
+    btn.Click();
+
+    CHECK_MSG(count == 1, "template SetCallback should accept lambda");
+}
+
+// ========================================================
+// Test 49: Template SetCallback with function pointer
+// ========================================================
+namespace {
+int g_funcPtrCount = 0;
+void IncrementGlobal() { ++g_funcPtrCount; }
+} // namespace
+
+TEST_CASE("Template SetCallback with function pointer", "[WebButton]") {
+    WebButton btn("test");
+    g_funcPtrCount = 0;
+
+    btn.SetCallback(&IncrementGlobal);
+    btn.Click();
+
+    CHECK_MSG(g_funcPtrCount == 1, "template SetCallback should accept function pointer");
+}
+
+// ========================================================
+// Test 50: Template SetCallback with functor
+// ========================================================
+TEST_CASE("Template SetCallback with functor", "[WebButton]") {
+    struct ClickCounter {
+        int& count;
+        void operator()() { ++count; }
+    };
+
+    WebButton btn("test");
+    int count = 0;
+
+    btn.SetCallback(ClickCounter{count});
+    btn.Click();
+
+    CHECK_MSG(count == 1, "template SetCallback should accept functor");
+}
+
+// ========================================================
+// Test 51: Template SetCallback replaces previous callback
+// ========================================================
+TEST_CASE("Template SetCallback replaces previous callback", "[WebButton]") {
+    WebButton btn("test");
+    int first = 0;
+    int second = 0;
+
+    btn.SetCallback([&first]() { ++first; });
+    btn.Click();
+    CHECK_MSG(first == 1, "first callback should fire");
+
+    btn.SetCallback([&second]() { ++second; });
+    btn.Click();
+    CHECK_MSG(first == 1, "first should not fire again");
+    CHECK_MSG(second == 1, "second callback should fire");
+}
+
+// ========================================================
+// Test 52: SetCanvasRect does not crash
+// ========================================================
+TEST_CASE("SetCanvasRect does not crash", "[WebButton]") {
+    WebButton btn("test");
+    REQUIRE_NOTHROW(btn.SetCanvasRect(10.0f, 20.0f, 100.0f, 50.0f));
+}
+
+// ========================================================
+// Test 53: SetCanvasRect with default dimensions
+// ========================================================
+TEST_CASE("SetCanvasRect with default dimensions", "[WebButton]") {
+    WebButton btn("test");
+    REQUIRE_NOTHROW(btn.SetCanvasRect(5.0f, 5.0f));
+}
+
+// ========================================================
+// Test 54: SetCanvasRect at origin
+// ========================================================
+TEST_CASE("SetCanvasRect at origin", "[WebButton]") {
+    WebButton btn("test");
+    REQUIRE_NOTHROW(btn.SetCanvasRect(0.0f, 0.0f, 80.0f, 30.0f));
+}
+
+// ========================================================
+// Test 55: SetCanvasRect with negative position
+// ========================================================
+TEST_CASE("SetCanvasRect with negative position", "[WebButton]") {
+    WebButton btn("test");
+    REQUIRE_NOTHROW(btn.SetCanvasRect(-10.0f, -20.0f, 80.0f, 30.0f));
+}
+
+// ========================================================
+// Test 56: WebButton implements ICanvasElement
+// ========================================================
+TEST_CASE("WebButton implements ICanvasElement", "[WebButton]") {
+    STATIC_REQUIRE(std::is_base_of_v<ICanvasElement, WebButton>);
+}
+
+// ========================================================
+// Test 57: ZIndex default is zero
+// ========================================================
+TEST_CASE("ZIndex default is zero", "[WebButton]") {
+    WebButton btn("test");
+    CHECK_MSG(btn.ZIndex() == 0, "default z-index should be 0");
+}
+
+// ========================================================
+// Test 58: SetZIndex and ZIndex
+// ========================================================
+TEST_CASE("SetZIndex and ZIndex", "[WebButton]") {
+    WebButton btn("test");
+    btn.SetZIndex(5);
+    CHECK_MSG(btn.ZIndex() == 5, "z-index should be 5");
+    btn.SetZIndex(-1);
+    CHECK_MSG(btn.ZIndex() == -1, "z-index should accept negative values");
+}
+
+// ========================================================
+// Test 59: ICanvasElement Visible default is true
+// ========================================================
+TEST_CASE("ICanvasElement Visible default is true", "[WebButton]") {
+    WebButton btn("test");
+    CHECK_MSG(btn.Visible() == true, "canvas visibility should default to true");
+}
+
+// ========================================================
+// Test 60: SetVisible toggles canvas visibility
+// ========================================================
+TEST_CASE("SetVisible toggles canvas visibility", "[WebButton]") {
+    WebButton btn("test");
+    btn.SetVisible(false);
+    CHECK_MSG(btn.Visible() == false, "should be hidden");
+    btn.SetVisible(true);
+    CHECK_MSG(btn.Visible() == true, "should be visible again");
+}
+
+// ========================================================
+// Test 61: HandleClick on moved-from object is safe
+// ========================================================
+TEST_CASE("HandleClick on moved-from object is safe", "[WebButton]") {
+    WebButton original("move-handle");
+    original.SetCallback([]() {});
+    WebButton moved(std::move(original));
+
+    REQUIRE_NOTHROW(original.HandleClick());
+}
+
+// ========================================================
+// Test 62: Very long label string
+// ========================================================
+TEST_CASE("Very long label string", "[WebButton]") {
+    std::string longLabel(10000, 'A');
+    WebButton btn(longLabel);
+    CHECK_MSG(btn.GetLabel() == longLabel, "should store very long label");
+    CHECK_MSG(btn.GetLabel().size() == 10000, "label length should be 10000");
+}
+
+// ========================================================
+// Test 63: SetLabel with special characters
+// ========================================================
+TEST_CASE("SetLabel with special characters", "[WebButton]") {
+    WebButton btn("test");
+    btn.SetLabel("<script>alert('xss')</script>");
+    CHECK_MSG(btn.GetLabel() == "<script>alert('xss')</script>", "should store raw HTML string");
+}
+
+// ========================================================
+// Test 64: SetLabel with unicode characters
+// ========================================================
+TEST_CASE("SetLabel with unicode characters", "[WebButton]") {
+    WebButton btn("test");
+    btn.SetLabel("Click here \xC3\xA9\xC3\xA0\xC3\xBC");
+    CHECK_MSG(!btn.GetLabel().empty(), "unicode label should not be empty");
+}
+
+// ========================================================
+// Test 65: SyncFromModel after move assignment
+// ========================================================
+TEST_CASE("SyncFromModel after move assignment", "[WebButton]") {
+    WebButton src("sync-src");
+    src.SetSize(75, 25);
+    src.SetBackgroundColor("#123456");
+    src.Disable();
+
+    WebButton dest("sync-dest");
+    dest = std::move(src);
+    REQUIRE_NOTHROW(dest.SyncFromModel());
+
+    CHECK_MSG(dest.GetLabel() == "sync-src", "label should transfer");
+    CHECK_MSG(dest.GetWidth() == 75, "width should transfer");
+    CHECK_MSG(dest.IsEnabled() == false, "disabled state should transfer");
+}
+
 #endif // __EMSCRIPTEN__


### PR DESCRIPTION
Changes:

- Updated WebButton.md to reflect current implementation (was outdated). Added ICanvasElement interface, template SetCallback, cse498 namespace, PascalCase method names, CMake build instructions, and updated changelog.
- Expanded WebButtonTest.cpp from 47 to 65 test cases (156 assertions). New coverage includes template SetCallback (lambda, function pointer, functor), SetCanvasRect, ICanvasElement type checks, ZIndex, canvas visibility, HandleClick on moved-from objects, long/unicode/special-character labels, and SyncFromModel after move assignment.
- Fixed small conditional bug in IDomElement.hpp RemoveChild: changed mElement.isNull() && mElement.isUndefined() to mElement.isNull() || mElement.isUndefined() (an element cannot be both null and undefined simultaneously, so the warning never triggered).